### PR TITLE
Add CPU and CUDA requirements files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ metrics.json
 *.csv
 *.log
 *.txt
+# Dependency manifests
+!requirements.txt
+!requirements-*.txt
 
 # Temporary files
 temp/

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,8 @@
+# Core dependencies for running NFTM experiments with CUDA acceleration
+--extra-index-url https://download.pytorch.org/whl/cu118
+numpy>=1.23
+matplotlib>=3.7
+pillow>=10.0
+imageio>=2.31
+torch==2.1.2+cu118
+torchvision==0.16.2+cu118

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Core dependencies for running NFTM experiments without CUDA acceleration
+numpy>=1.23
+matplotlib>=3.7
+pillow>=10.0
+imageio>=2.31
+torch>=2.1
+torchvision>=0.16


### PR DESCRIPTION
## Summary
- add CPU-only and CUDA-enabled requirements files for installing NFTM dependencies
- update .gitignore to allow tracking dependency requirement manifests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df02aee6bc83288c4a00e1f4854842