### PR TITLE
Add Tiny U-Net model and metrics utilities for training script

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+
+Reduction = Literal["mean", "none"]
+
+
+def param_count(model: torch.nn.Module) -> int:
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+
+def psnr(pred: torch.Tensor, target: torch.Tensor, reduction: Reduction = "mean") -> torch.Tensor:
+    pred = pred.float()
+    target = target.float()
+    mse = F.mse_loss(pred, target, reduction="none")
+    dims = tuple(range(1, mse.ndim))
+    mse = mse.mean(dim=dims)
+    psnr_vals = 10.0 * torch.log10(4.0 / mse.clamp_min(1e-12))
+    if reduction == "none":
+        return psnr_vals
+    return psnr_vals.mean()
+
+
+def _gaussian_window(kernel_size: int, sigma: float, channels: int, device, dtype) -> torch.Tensor:
+    coords = torch.arange(kernel_size, device=device, dtype=dtype) - kernel_size // 2
+    gauss = torch.exp(-(coords ** 2) / (2 * sigma ** 2))
+    kernel_1d = gauss / gauss.sum()
+    kernel_2d = kernel_1d[:, None] @ kernel_1d[None, :]
+    window = kernel_2d.expand(channels, 1, kernel_size, kernel_size)
+    return window
+
+
+def ssim(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    reduction: Reduction = "mean",
+    kernel_size: int = 11,
+    sigma: float = 1.5,
+    data_range: float = 2.0,
+) -> torch.Tensor:
+    pred = pred.float()
+    target = target.float()
+    channel = pred.size(1)
+    window = _gaussian_window(kernel_size, sigma, channel, pred.device, pred.dtype)
+    padding = kernel_size // 2
+
+    mu_pred = F.conv2d(pred, window, padding=padding, groups=channel)
+    mu_target = F.conv2d(target, window, padding=padding, groups=channel)
+
+    mu_pred_sq = mu_pred.pow(2)
+    mu_target_sq = mu_target.pow(2)
+    mu_pred_target = mu_pred * mu_target
+
+    sigma_pred_sq = F.conv2d(pred * pred, window, padding=padding, groups=channel) - mu_pred_sq
+    sigma_target_sq = F.conv2d(target * target, window, padding=padding, groups=channel) - mu_target_sq
+    sigma_pred_target = F.conv2d(pred * target, window, padding=padding, groups=channel) - mu_pred_target
+
+    c1 = (0.01 * data_range) ** 2
+    c2 = (0.03 * data_range) ** 2
+
+    numerator = (2 * mu_pred_target + c1) * (2 * sigma_pred_target + c2)
+    denominator = (mu_pred_sq + mu_target_sq + c1) * (sigma_pred_sq + sigma_target_sq + c2)
+    ssim_map = numerator / denominator
+
+    dims = tuple(range(1, ssim_map.ndim))
+    ssim_vals = ssim_map.mean(dim=dims)
+    if reduction == "none":
+        return ssim_vals
+    return ssim_vals.mean()
+
+
+_lpips_cache: dict[tuple[torch.device, str], torch.nn.Module] = {}
+
+
+def lpips_dist(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    net: str = "alex",
+    reduction: Reduction = "mean",
+) -> torch.Tensor:
+    pred = pred.to(dtype=torch.float32)
+    target = target.to(dtype=torch.float32)
+    if pred.shape != target.shape:
+        raise ValueError("Input tensors to lpips_dist must have the same shape")
+
+    try:
+        import lpips
+    except ImportError as exc:  # pragma: no cover - dependency error surfaced to caller
+        raise ImportError("lpips package is required for lpips_dist") from exc
+
+    key = (pred.device, net)
+    model = _lpips_cache.get(key)
+    if model is None:
+        model = lpips.LPIPS(net=net).to(pred.device)
+        model.eval()
+        _lpips_cache[key] = model
+
+    with torch.no_grad():
+        values = model(pred, target)
+
+    values = values.view(values.size(0), -1).mean(dim=1)
+    if reduction == "none":
+        return values
+    return values.mean()

--- a/train_unet.py
+++ b/train_unet.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Train a Tiny U-Net for CIFAR-10 masked inpainting."""
+
+import argparse
+import json
+import os
+import time
+import copy
+from typing import Dict, Optional, Tuple
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+import torchvision as tv
+import torchvision.utils as vutils
+
+from unet_model import TinyUNet
+from metrics import psnr as psnr_metric, ssim as ssim_metric, lpips_dist, param_count
+from image_inpainting import (
+    make_transforms,
+    random_mask,
+    corrupt_images,
+    clamp_known,
+    tv_l1,
+    set_seed,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train Tiny U-Net on CIFAR-10 inpainting")
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--lr", type=float, default=2e-3)
+    parser.add_argument("--weight_decay", type=float, default=1e-4)
+    parser.add_argument("--tv_weight", type=float, default=0.01)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--save_dir", type=str, default="out_unet")
+    parser.add_argument("--target_params", type=int, default=46375)
+    parser.add_argument("--base", type=int, default=10, help="Base channel width for TinyUNet")
+    parser.add_argument("--num_workers", type=int, default=2)
+    parser.add_argument("--device", type=str, default="auto")
+    parser.add_argument("--data_root", type=str, default="./data")
+    parser.add_argument("--eval_subset", type=int, default=2000,
+                        help="Number of test images used for per-epoch validation (0 to disable)")
+    parser.add_argument("--grad_clip", type=float, default=1.0)
+    parser.add_argument("--noise_std", type=float, default=0.3)
+    return parser.parse_args()
+
+
+def get_device(device_arg: str) -> torch.device:
+    if device_arg == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(device_arg)
+
+
+def instantiate_unet(base_width: int) -> nn.Module:
+    """Instantiate TinyUNet handling minor signature variations."""
+    options = [
+        {"in_channels": 4, "out_channels": 3, "base": base_width},
+        {"in_channels": 4, "out_channels": 3, "base_channels": base_width},
+        {"in_channels": 4, "out_channels": 3, "width": base_width},
+        {"in_ch": 4, "out_ch": 3, "base": base_width},
+        {"in_ch": 4, "out_ch": 3, "base_channels": base_width},
+        {"in_ch": 4, "out_ch": 3, "width": base_width},
+    ]
+    for kwargs in options:
+        try:
+            return TinyUNet(**kwargs)
+        except TypeError:
+            continue
+    # Fallback to positional instantiation attempts
+    try:
+        return TinyUNet(4, 3, base_width)
+    except TypeError:
+        pass
+    try:
+        return TinyUNet(4, 3)
+    except TypeError as exc:
+        raise RuntimeError("Unable to instantiate TinyUNet with provided arguments") from exc
+
+
+def prepare_dataloaders(args: argparse.Namespace, device: torch.device) -> Tuple[DataLoader, DataLoader]:
+    transform = make_transforms()
+    train_set = tv.datasets.CIFAR10(root=args.data_root, train=True, download=True, transform=transform)
+    test_set = tv.datasets.CIFAR10(root=args.data_root, train=False, download=True, transform=transform)
+
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+        drop_last=True,
+    )
+
+    test_loader = DataLoader(
+        test_set,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+    )
+    return train_loader, test_loader
+
+
+def masked_psnr(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    mask_expand = mask.expand_as(pred)
+    diff = (pred - target) * mask_expand
+    denom = mask_expand.flatten(1).sum(dim=1).clamp_min(1e-6)
+    mse = diff.pow(2).flatten(1).sum(dim=1) / denom
+    psnr_vals = 10.0 * torch.log10(4.0 / mse.clamp_min(1e-12))
+    return psnr_vals
+
+
+def masked_metric(metric_fn, pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    mask_expand = mask.expand_as(pred)
+    masked_pred = (pred * mask_expand).contiguous()
+    masked_target = (target * mask_expand).contiguous()
+    values = metric_fn(masked_pred, masked_target, reduction="none")
+    if isinstance(values, torch.Tensor):
+        return values
+    return torch.tensor(values, device=pred.device)
+
+
+def train_one_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    tv_weight: float,
+    noise_std: float,
+    grad_clip: float,
+) -> float:
+    model.train()
+    total_loss = 0.0
+    num_batches = 0
+
+    for imgs, _ in loader:
+        imgs = imgs.to(device, non_blocking=True)
+        M = random_mask(imgs, p_missing=(0.25, 0.5), block_prob=0.5, min_blocks=1, max_blocks=3)
+        I0 = corrupt_images(imgs, M, noise_std=noise_std)
+        X = torch.cat([I0, M], dim=1)
+
+        optimizer.zero_grad(set_to_none=True)
+        pred = model(X)
+        pred = clamp_known(pred, imgs, M)
+
+        l1_loss = F.l1_loss(pred, imgs)
+        tv_loss = tv_l1(pred)
+        loss = l1_loss + tv_weight * tv_loss
+        loss.backward()
+        nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        optimizer.step()
+
+        total_loss += loss.item()
+        num_batches += 1
+
+    return total_loss / max(1, num_batches)
+
+
+def evaluate_subset(
+    model: nn.Module,
+    loader: DataLoader,
+    device: torch.device,
+    max_images: int,
+    noise_std: float,
+) -> Optional[float]:
+    if max_images <= 0:
+        return None
+
+    model.eval()
+    psnr_vals = []
+    seen = 0
+    with torch.no_grad():
+        for imgs, _ in loader:
+            imgs = imgs.to(device, non_blocking=True)
+            M = random_mask(imgs, p_missing=(0.25, 0.5), block_prob=0.5, min_blocks=1, max_blocks=3)
+            I0 = corrupt_images(imgs, M, noise_std=noise_std)
+            X = torch.cat([I0, M], dim=1)
+            pred = model(X)
+            pred = clamp_known(pred, imgs, M)
+            batch_psnr = psnr_metric(pred, imgs, reduction="none")
+            remaining = max_images - seen
+            if remaining <= 0:
+                break
+            batch_vals = batch_psnr.detach().cpu().tolist()
+            psnr_vals.extend(batch_vals[:remaining])
+            seen += min(len(batch_vals), remaining)
+            if seen >= max_images:
+                break
+    if not psnr_vals:
+        return None
+    return sum(psnr_vals) / len(psnr_vals)
+
+
+def compute_metrics(
+    model: nn.Module,
+    loader: DataLoader,
+    device: torch.device,
+    noise_std: float,
+) -> Tuple[Dict[str, float], Dict[str, torch.Tensor]]:
+    model.eval()
+    agg = {
+        "psnr_all": 0.0,
+        "psnr_miss": 0.0,
+        "ssim_all": 0.0,
+        "ssim_miss": 0.0,
+        "lpips_all": 0.0,
+        "lpips_miss": 0.0,
+    }
+    total_images = 0
+    sample_tensors: Dict[str, torch.Tensor] = {}
+
+    with torch.no_grad():
+        for imgs, _ in loader:
+            imgs = imgs.to(device, non_blocking=True)
+            M = random_mask(imgs, p_missing=(0.25, 0.5), block_prob=0.5, min_blocks=1, max_blocks=3)
+            I0 = corrupt_images(imgs, M, noise_std=noise_std)
+            X = torch.cat([I0, M], dim=1)
+            pred = model(X)
+            pred = clamp_known(pred, imgs, M)
+
+            miss = 1.0 - M
+
+            batch_metrics = {
+                "psnr_all": psnr_metric(pred, imgs, reduction="none"),
+                "psnr_miss": masked_psnr(pred, imgs, miss),
+                "ssim_all": ssim_metric(pred, imgs, reduction="none"),
+                "ssim_miss": masked_metric(ssim_metric, pred, imgs, miss),
+                "lpips_all": lpips_dist(pred.contiguous(), imgs.contiguous(), reduction="none"),
+                "lpips_miss": masked_metric(lpips_dist, pred, imgs, miss),
+            }
+
+            batch_size = imgs.size(0)
+            for key, value in batch_metrics.items():
+                tensor_val = value.detach()
+                if tensor_val.ndim == 0:
+                    agg[key] += float(tensor_val.cpu()) * batch_size
+                else:
+                    agg[key] += float(tensor_val.sum().cpu())
+            total_images += batch_size
+
+            if not sample_tensors:
+                sample_tensors = {
+                    "gt": imgs.detach().cpu(),
+                    "input": I0.detach().cpu(),
+                    "mask": M.detach().cpu(),
+                    "pred": pred.detach().cpu(),
+                }
+
+    if total_images == 0:
+        raise RuntimeError("Empty loader provided for evaluation")
+
+    for key in agg:
+        agg[key] /= total_images
+    return agg, sample_tensors
+
+
+def save_train_log(path: str, logs) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(logs, f, indent=2)
+
+
+def plot_psnr_curve(psnr_values, save_path: str) -> None:
+    if not psnr_values:
+        return
+    epochs = list(range(1, len(psnr_values) + 1))
+    plt.figure(figsize=(6, 4))
+    plt.plot(epochs, psnr_values, marker="o")
+    plt.xlabel("Epoch")
+    plt.ylabel("PSNR (dB)")
+    plt.title("Validation PSNR per Epoch")
+    plt.grid(True, linestyle="--", alpha=0.5)
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()
+
+
+def save_samples(sample_tensors: Dict[str, torch.Tensor], save_path: str) -> None:
+    if not sample_tensors:
+        return
+    gt = sample_tensors["gt"]
+    inp = sample_tensors["input"]
+    mask = sample_tensors["mask"]
+    pred = sample_tensors["pred"]
+
+    num_rows = min(6, gt.size(0))
+    panels = []
+    for i in range(num_rows):
+        gt_img = gt[i]
+        inp_img = inp[i]
+        mask_img = mask[i].expand_as(gt_img)
+        pred_img = pred[i]
+
+        panels.extend([gt_img, inp_img, mask_img * 2 - 1, pred_img])
+
+    grid = vutils.make_grid(panels, nrow=4, normalize=True, value_range=(-1, 1))
+    vutils.save_image(grid, save_path)
+
+
+def main():
+    args = parse_args()
+
+    os.makedirs(args.save_dir, exist_ok=True)
+    set_seed(args.seed)
+    device = get_device(args.device)
+    print(f"Using device: {device}")
+
+    train_loader, test_loader = prepare_dataloaders(args, device)
+
+    model = instantiate_unet(args.base)
+    model.to(device)
+    params = param_count(model)
+    print(f"Model parameters: {params}")
+    if args.target_params > 0:
+        lower = args.target_params * 0.95
+        upper = args.target_params * 1.05
+        if not (lower <= params <= upper):
+            print(
+                f"[Warning] Parameter count {params} outside ±5% of target {args.target_params}."
+            )
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+
+    val_history = []
+    logs = []
+    best_state = copy.deepcopy(model.state_dict())
+    best_metric = -float("inf")
+
+    for epoch in range(1, args.epochs + 1):
+        start = time.time()
+        train_loss = train_one_epoch(
+            model,
+            train_loader,
+            optimizer,
+            device,
+            args.tv_weight,
+            args.noise_std,
+            args.grad_clip,
+        )
+        elapsed = time.time() - start
+
+        val_psnr = evaluate_subset(model, test_loader, device, args.eval_subset, args.noise_std)
+        if val_psnr is not None:
+            val_history.append(val_psnr)
+            if val_psnr > best_metric:
+                best_metric = val_psnr
+                best_state = copy.deepcopy(model.state_dict())
+        else:
+            best_state = copy.deepcopy(model.state_dict())
+
+        logs.append(
+            {
+                "epoch": epoch,
+                "loss": train_loss,
+                "psnr_val": val_psnr,
+                "time_sec": elapsed,
+            }
+        )
+
+        print(
+            f"Epoch {epoch}/{args.epochs} - loss: {train_loss:.4f}"
+            + (f", val_psnr: {val_psnr:.2f}" if val_psnr is not None else "")
+            + f", time: {elapsed:.1f}s"
+        )
+
+    if best_metric == -float("inf"):
+        best_state = copy.deepcopy(model.state_dict())
+    model.load_state_dict(best_state)
+
+    metrics, sample_tensors = compute_metrics(model, test_loader, device, args.noise_std)
+    metrics["params"] = int(params)
+    metrics["seed"] = args.seed
+
+    metrics_path = os.path.join(args.save_dir, "metrics.json")
+    with open(metrics_path, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"Saved metrics to {metrics_path}")
+
+    ckpt = {
+        "model": best_state,
+        "args": vars(args),
+        "params": int(params),
+        "best_metric": float(metrics["psnr_all"]),
+    }
+    torch.save(ckpt, os.path.join(args.save_dir, "ckpt.pt"))
+
+    save_train_log(os.path.join(args.save_dir, "train_log.json"), logs)
+    plot_psnr_curve(val_history, os.path.join(args.save_dir, "psnr_curve.png"))
+    save_samples(sample_tensors, os.path.join(args.save_dir, "pred_samples.png"))
+
+
+if __name__ == "__main__":
+    main()

--- a/unet_model.py
+++ b/unet_model.py
@@ -1,0 +1,70 @@
+import torch
+import torch
+import torch.nn as nn
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class TinyUNet(nn.Module):
+    """A lightweight U-Net for 32x32 inpainting tasks."""
+
+    def __init__(
+        self,
+        in_channels: int = 4,
+        out_channels: int = 3,
+        base: int = 32,
+    ) -> None:
+        super().__init__()
+        width = base
+
+        self.enc1 = ConvBlock(in_channels, width)
+        self.pool1 = nn.MaxPool2d(kernel_size=2)
+
+        self.enc2 = ConvBlock(width, width * 2)
+        self.pool2 = nn.MaxPool2d(kernel_size=2)
+
+        self.bottleneck = ConvBlock(width * 2, width * 4)
+
+        self.up2 = nn.ConvTranspose2d(width * 4, width * 2, kernel_size=2, stride=2)
+        self.dec2 = ConvBlock(width * 4, width * 2)
+
+        self.up1 = nn.ConvTranspose2d(width * 2, width, kernel_size=2, stride=2)
+        self.dec1 = ConvBlock(width * 2, width)
+
+        self.out_conv = nn.Conv2d(width, out_channels, kernel_size=3, padding=1)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        for module in self.modules():
+            if isinstance(module, nn.Conv2d) or isinstance(module, nn.ConvTranspose2d):
+                nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        enc1 = self.enc1(x)
+        enc2 = self.enc2(self.pool1(enc1))
+        bottleneck = self.bottleneck(self.pool2(enc2))
+
+        dec2 = self.up2(bottleneck)
+        dec2 = torch.cat([dec2, enc2], dim=1)
+        dec2 = self.dec2(dec2)
+
+        dec1 = self.up1(dec2)
+        dec1 = torch.cat([dec1, enc1], dim=1)
+        dec1 = self.dec1(dec1)
+
+        return torch.tanh(self.out_conv(dec1))


### PR DESCRIPTION
## Summary
- add reusable TinyUNet implementation that targets the requested parameter budget
- provide standalone PSNR/SSIM/LPIPS helpers with reduction control for masked metrics
- refine train_unet to use the new helpers, handle masked aggregation, and guard validation-less runs

## Testing
- python train_unet.py --epochs 1 --save_dir tmp_unet --batch_size 64 *(fails: torchvision cannot download CIFAR-10 because of a 403 tunnel restriction in the execution environment)*
- python -m py_compile train_unet.py unet_model.py metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dff54f8178832897e2634c2a2da789