### PR TITLE
Add NFTM controller sweeps to inpainting driver

### DIFF
--- a/drivers/run_all_inpainting.py
+++ b/drivers/run_all_inpainting.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import os
 import sys
 import subprocess
 import time
 from datetime import datetime
-from typing import Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 
 def _ensure_dir(path: str) -> None:
@@ -97,11 +98,174 @@ def _pretty_print(summary: Dict[str, Dict[str, float]], methods: Iterable[str]) 
         print(" | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row)))
 
 
+def _resolve_mask_dir(mask_dir: str | None) -> str | None:
+    if not mask_dir:
+        return None
+    script_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "image_inpainting.py")
+    )
+    try:
+        with open(script_path, "r", encoding="utf-8") as fp:
+            if "--mask_dir" in fp.read():
+                return mask_dir
+    except OSError:
+        pass
+    print("[warn] --mask_dir ignored; image_inpainting.py does not support this argument")
+    return None
+
+
+def _run_nftm_commands(
+    py_executable: str,
+    controller_dirs: Dict[str, str],
+    *,
+    epochs: int,
+    k_train: int,
+    k_eval: int,
+    loss: str,
+    device: str,
+    seed: int,
+    extra_args: List[str],
+    mask_dir: str | None,
+) -> List[Tuple[str, str]]:
+    runs: List[Tuple[str, str]] = []
+    for controller, save_dir in controller_dirs.items():
+        cmd = [
+            py_executable,
+            "image_inpainting.py",
+            "--controller",
+            controller,
+            "--save_dir",
+            save_dir,
+            "--epochs",
+            str(epochs),
+            "--K_train",
+            str(k_train),
+            "--K_eval",
+            str(k_eval),
+            "--loss",
+            loss,
+            "--seed",
+            str(seed),
+            "--device",
+            device,
+            "--save_metrics",
+        ]
+        if mask_dir and "--mask_dir" not in extra_args:
+            cmd.extend(["--mask_dir", mask_dir])
+        if extra_args:
+            cmd.extend(extra_args)
+        stage_name = f"nftm_{controller}"
+        _run_stage(stage_name, cmd)
+        runs.append((controller, save_dir))
+    return runs
+
+
+def _collect_nftm_metrics(
+    runs: List[Tuple[str, str]],
+    *,
+    loss: str,
+    epochs: int,
+    k_train: int,
+    k_eval: int,
+    device: str,
+    seed: int,
+) -> List[Dict[str, Any]]:
+    collected: List[Dict[str, Any]] = []
+    for controller, save_dir in runs:
+        metrics_path = os.path.join(save_dir, "metrics.json")
+        metrics = _load_metrics(metrics_path)
+        row: Dict[str, Any] = {
+            "controller": controller,
+            "loss": metrics.get("loss_mode", loss),
+            "epochs": metrics.get("epochs", epochs),
+            "K_train": metrics.get("K_train", k_train),
+            "K_eval": metrics.get("K_eval", k_eval),
+            "device": metrics.get("device", device),
+            "seed": metrics.get("seed", seed),
+            "final_psnr": metrics.get("final_psnr"),
+            "save_dir": save_dir,
+        }
+        for key in [
+            "psnr_all",
+            "psnr_miss",
+            "ssim_all",
+            "ssim_miss",
+            "lpips_all",
+            "lpips_miss",
+            "runtime_ms_per_image",
+        ]:
+            row[key] = metrics.get(key)
+        collected.append(row)
+    return collected
+
+
+def _write_nftm_summary_csv(path: str, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    columns = [
+        "controller",
+        "loss",
+        "epochs",
+        "K_train",
+        "K_eval",
+        "device",
+        "seed",
+        "psnr_all",
+        "psnr_miss",
+        "ssim_all",
+        "ssim_miss",
+        "lpips_all",
+        "lpips_miss",
+        "runtime_ms_per_image",
+        "final_psnr",
+        "save_dir",
+    ]
+    _ensure_dir(os.path.dirname(path) or ".")
+    with open(path, "w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: row.get(column, "") for column in columns})
+    print(f"[info] NFTM summary written to {path}")
+
+
+def _print_nftm_table(rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    columns = [
+        "controller",
+        "psnr_all",
+        "psnr_miss",
+        "ssim_all",
+        "ssim_miss",
+        "lpips_all",
+        "lpips_miss",
+        "final_psnr",
+    ]
+    widths = [len(col) for col in columns]
+    table_rows: List[List[str]] = []
+    for row in rows:
+        formatted_row: List[str] = []
+        for idx, column in enumerate(columns):
+            if column == "controller":
+                cell = str(row.get(column, ""))
+            else:
+                cell = _format_float(row.get(column))
+            widths[idx] = max(widths[idx], len(cell))
+            formatted_row.append(cell)
+        table_rows.append(formatted_row)
+    print("\nNFTM SUMMARY")
+    print(" | ".join(columns[idx].ljust(widths[idx]) for idx in range(len(columns))))
+    print("-+-".join("-" * width for width in widths))
+    for formatted_row in table_rows:
+        print(" | ".join(formatted_row[idx].ljust(widths[idx]) for idx in range(len(columns))))
+
+
 def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--out", type=str, default="out_all")
-    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=None)
     parser.add_argument("--batch_size", type=int, default=256)
     parser.add_argument("--lr", type=float, default=2e-3)
     parser.add_argument("--wd", type=float, default=1e-4)
@@ -118,11 +282,28 @@ def main(argv: List[str] | None = None) -> None:
         "--device", type=str, default="auto", choices=["auto", "cpu", "cuda"]
     )
     parser.add_argument("--include_nftm", action="store_true")
+    parser.add_argument("--save_root", type=str, default="runs/inpainting")
+    parser.add_argument("--mask_dir", type=str)
+    parser.add_argument("--loss", type=str, default="homo", choices=["homo", "hetero"])
+    parser.add_argument("--K_train", type=int, default=None)
+    parser.add_argument("--K_eval", type=int, default=None)
+    parser.add_argument("--extra", nargs=argparse.REMAINDER, default=[])
     args = parser.parse_args(argv)
+
+    baseline_epochs = args.epochs if args.epochs is not None else 20
+    nftm_epochs = args.epochs if args.epochs is not None else 30
+    nftm_k_train = args.K_train if args.K_train is not None else 20
+    nftm_k_eval = args.K_eval if args.K_eval is not None else 30
 
     requested_device, resolved_device = _resolve_device(args.device)
     base_dir = args.out
     py_executable = sys.executable
+
+    nftm_controller_dirs = {
+        "dense": os.path.join(args.save_root, "nftm_dense"),
+        "unet": os.path.join(args.save_root, "nftm_unet"),
+    }
+    mask_dir_value = _resolve_mask_dir(args.mask_dir if args.include_nftm else None)
 
     dirs = {
         "unet": os.path.join(base_dir, "unet"),
@@ -135,6 +316,7 @@ def main(argv: List[str] | None = None) -> None:
     for path in [base_dir, *dirs.values()]:
         _ensure_dir(path)
 
+    nftm_runs: List[Tuple[str, str]] = []
     try:
         _run_stage(
             "train_unet",
@@ -142,7 +324,7 @@ def main(argv: List[str] | None = None) -> None:
                 py_executable,
                 "train_unet.py",
                 "--epochs",
-                str(args.epochs),
+                str(baseline_epochs),
                 "--batch_size",
                 str(args.batch_size),
                 "--lr",
@@ -226,6 +408,21 @@ def main(argv: List[str] | None = None) -> None:
                     dirs["nftm"],
                 ],
             )
+        if args.include_nftm:
+            for path in [args.save_root, *nftm_controller_dirs.values()]:
+                _ensure_dir(path)
+            nftm_runs = _run_nftm_commands(
+                py_executable,
+                nftm_controller_dirs,
+                epochs=nftm_epochs,
+                k_train=nftm_k_train,
+                k_eval=nftm_k_eval,
+                loss=args.loss,
+                device=resolved_device,
+                seed=args.seed,
+                extra_args=list(args.extra),
+                mask_dir=mask_dir_value,
+            )
     except subprocess.CalledProcessError as exc:  # pragma: no cover - runtime failure path
         cmd = " ".join(str(part) for part in exc.cmd)
         print(f"[error] command failed with exit code {exc.returncode}: {cmd}")
@@ -246,7 +443,7 @@ def main(argv: List[str] | None = None) -> None:
         "device": resolved_device,
         "requested_device": requested_device,
         "timestamp": datetime.utcnow().isoformat() + "Z",
-        "epochs": args.epochs,
+        "epochs": baseline_epochs,
         "batch_size": args.batch_size,
     }
 
@@ -256,6 +453,24 @@ def main(argv: List[str] | None = None) -> None:
     print(f"[info] summary written to {summary_path}")
 
     _pretty_print(summary, ["unet", "tvl1", "nftm"])
+
+    if args.include_nftm and nftm_runs:
+        try:
+            nftm_rows = _collect_nftm_metrics(
+                nftm_runs,
+                loss=args.loss,
+                epochs=nftm_epochs,
+                k_train=nftm_k_train,
+                k_eval=nftm_k_eval,
+                device=resolved_device,
+                seed=args.seed,
+            )
+        except FileNotFoundError as exc:
+            print(f"[error] {exc}")
+            raise SystemExit(1)
+        summary_csv_path = os.path.join(args.save_root, "summary.csv")
+        _write_nftm_summary_csv(summary_csv_path, nftm_rows)
+        _print_nftm_table(nftm_rows)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- extend the inpainting driver CLI with options for NFTM runs and passthrough flags
- orchestrate dense and UNet NFTM controllers with shared settings and metrics collection
- write a summary CSV and console table from metrics.json outputs for the NFTM runs

## Testing
- python -m compileall drivers/run_all_inpainting.py

------
https://chatgpt.com/codex/tasks/task_e_68e95bac45888328a50f7463b4f257ea